### PR TITLE
warnings module new behavior in Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 env:
   - PYTHON_VERSION="2.7"
-  - PYTHON_VERSION="3.5"
+  - PYTHON_VERSION="3.6"
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh

--- a/plate_mapper/plate_mapper.py
+++ b/plate_mapper/plate_mapper.py
@@ -197,7 +197,7 @@ def plate_mapper(input_f, barseq_f, output_f, names_f=None, special_f=None,
 
     # Display warning message
     if warning:
-        warnings.formatwarning = lambda msg, *a: str(msg)
+        warnings.formatwarning = lambda msg, cat, fname, lineno, line: str(msg)
         warnings.warn('Warning:\n%s' % warning)
 
     print('Task completed.')


### PR DESCRIPTION
the `warnings` module behaves slightly differently in Python 3.6, comparing to 3.5 and 2.7. Specifically, the magic command
```
warnings.formatwarning = lambda message, *args: str(message)
```
not longer works. It triggers an error:
```
<lambda>() got an unexpected keyword argument 'line'
```
To solve the problem, one has to list all arguments of `formatwarning`:
```
warnings.formatwarning = lambda message, category, filename, lineno, line: str(message)
```
